### PR TITLE
Add rm command, fix ps branch display, and improve watch command relaunch handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Resume watching a previously stopped project.
 
 ---
 
+### `fleet rm <id>`
+removing a monitored project from the watch list.
+
+---
+
 ## YAML Configuration
 
 Each project has a `fleet.yml` file defining its update process and optional conflict or post-update actions.

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,7 +28,7 @@ pub fn build_watch_request(cli: &Cli, repo: Repo) -> Result<DaemonRequest> {
         Commands::Logs { id_or_name } => Ok(build_logs_request(id_or_name, repo)),
         Commands::Stop { id } => Ok(DaemonRequest::StopWatch { id: id.to_string() }),
         Commands::Up { id } => Ok(DaemonRequest::UpWatch { id: id.to_string() }),
-        _ => Err(anyhow::anyhow!("Unsuported command")),
+        Commands::Rm { id } => Ok(DaemonRequest::RmWatch { id: id.to_string() }),
     }
 }
 


### PR DESCRIPTION
## Changes introduced

### 1. Added `rm` command
- Allows removing a monitored project from the watch list.
- Ensures proper cleanup to prevent residual state.

### 2. Fixed `ps` branch display
- Corrected incorrect or missing branch names in the `ps` command output.
- Improves clarity when listing monitored projects.

### 3. Improved watch command relaunch behavior
- If a project is already monitored, the watch command does nothing (avoids duplication).
- If the project exists but the user specifies a new branch, we:
  - Keep the same project ID.
  - Update `last_commit` to prevent false positives.

## Why these changes are needed
- The `rm` command was missing, making it impossible to remove projects cleanly.
- Branch display in `ps` was misleading or unclear in some cases.
- Relaunching `watch` on an existing project could cause duplicate entries or outdated commit tracking.
