### PR TITLE
Fix watch command branch handling and update tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-# Nom du projet
 PROJECT_NAME=fleet
 SERVICE_NAME=fleetd
 CARGO_BIN_DIR=$(HOME)/.cargo/bin

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,7 @@ install-service:
 
 uninstall: uninstall-service
 	@echo "🗑 Removing installed binaries..."
-	cargo uninstall $(PROJECT_NAME)
-	cargo uninstall $(SERVICE_NAME) || true
+	cargo uninstall fleet || true
 	@echo "🗑 Removing configuration..."
 	rm -rf $(CONFIG_DIR)
 	@echo "✅ Uninstalled successfully."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Nom du projet
+PROJECT_NAME=fleet
+SERVICE_NAME=fleetd
+CARGO_BIN_DIR=$(HOME)/.cargo/bin
+CONFIG_DIR=$(HOME)/.config/$(PROJECT_NAME)
+SERVICE_PATH=$(HOME)/.config/systemd/user/$(SERVICE_NAME).service
+
+.PHONY: install uninstall update build
+
+install: build install-service
+	@echo "✅ $(PROJECT_NAME) installed successfully."
+
+build:
+	@echo "📦 Building project in release mode..."
+	cargo install --path . --force
+
+install-service:
+	@echo "⚙ Creating and installing systemd service..."
+	mkdir -p $(HOME)/.config/systemd/user
+	printf "[Unit]\nDescription=Fleet Daemon\n\n[Service]\nExecStart=%s/fleetd\nRestart=always\n\n[Install]\nWantedBy=default.target\n" "$(CARGO_BIN_DIR)" > $(SERVICE_PATH)
+	systemctl --user daemon-reload
+	systemctl --user enable $(SERVICE_NAME)
+	systemctl --user start $(SERVICE_NAME)
+
+uninstall: uninstall-service
+	@echo "🗑 Removing installed binaries..."
+	cargo uninstall $(PROJECT_NAME)
+	cargo uninstall $(SERVICE_NAME) || true
+	@echo "🗑 Removing configuration..."
+	rm -rf $(CONFIG_DIR)
+	@echo "✅ Uninstalled successfully."
+
+uninstall-service:
+	@echo "⚙ Stopping and disabling systemd service..."
+	systemctl --user stop $(SERVICE_NAME) || true
+	systemctl --user disable $(SERVICE_NAME) || true
+	rm -f $(SERVICE_PATH)
+	systemctl --user daemon-reload
+
+update:
+	@echo "🔄 Updating project..."
+	cargo install --path . --force
+	systemctl --user restart $(SERVICE_NAME)

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -34,11 +34,11 @@ fn test_build_watch_request_branch_none() -> Result<(), Box<dyn std::error::Erro
 fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli {
         command: cli::Commands::Watch {
-            branch: Some(String::from("test")),
+            branch: Some(String::from("tests")),
         },
     };
 
-    let repo = Repo::build(None)?;
+    let repo = Repo::build(Some("tests".to_string()))?;
     let config = load_config(Path::new("./fleet.yml"))?;
 
     let watch_req = build_watch_request(&cli, repo.clone())?;
@@ -46,7 +46,7 @@ fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error::Erro
         watch_req,
         DaemonRequest::AddWatch {
             project_dir: std::env::current_dir()?.to_string_lossy().into_owned(),
-            branch: String::from("test"),
+            branch: String::from("tests"),
             repo,
             update_cmds: config.update
         }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -13,7 +13,7 @@ fn test_build_watch_request_branch_none() -> Result<(), Box<dyn std::error::Erro
         command: cli::Commands::Watch { branch: None },
     };
 
-    let repo = Repo::build()?;
+    let repo = Repo::build(None)?;
     let config = load_config(Path::new("./fleet.yml"))?;
 
     let watch_req = build_watch_request(&cli, repo.clone())?;
@@ -38,7 +38,7 @@ fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error::Erro
         },
     };
 
-    let repo = Repo::build()?;
+    let repo = Repo::build(None)?;
     let config = load_config(Path::new("./fleet.yml"))?;
 
     let watch_req = build_watch_request(&cli, repo.clone())?;

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -32,13 +32,13 @@ fn test_build_watch_request_branch_none() -> Result<(), Box<dyn std::error::Erro
 
 #[test]
 fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error::Error>> {
+    let repo = Repo::build(None)?;
     let cli = Cli {
         command: cli::Commands::Watch {
-            branch: Some(String::from("main")),
+            branch: Some(repo.branch.clone()),
         },
     };
 
-    let repo = Repo::build(Some("main".to_string()))?;
     let config = load_config(Path::new("./fleet.yml"))?;
 
     let watch_req = build_watch_request(&cli, repo.clone())?;
@@ -46,7 +46,7 @@ fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error::Erro
         watch_req,
         DaemonRequest::AddWatch {
             project_dir: std::env::current_dir()?.to_string_lossy().into_owned(),
-            branch: String::from("main"),
+            branch: repo.branch.clone(),
             repo,
             update_cmds: config.update
         }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -34,11 +34,11 @@ fn test_build_watch_request_branch_none() -> Result<(), Box<dyn std::error::Erro
 fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli {
         command: cli::Commands::Watch {
-            branch: Some(String::from("tests")),
+            branch: Some(String::from("main")),
         },
     };
 
-    let repo = Repo::build(Some("tests".to_string()))?;
+    let repo = Repo::build(Some("main".to_string()))?;
     let config = load_config(Path::new("./fleet.yml"))?;
 
     let watch_req = build_watch_request(&cli, repo.clone())?;
@@ -46,7 +46,7 @@ fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error::Erro
         watch_req,
         DaemonRequest::AddWatch {
             project_dir: std::env::current_dir()?.to_string_lossy().into_owned(),
-            branch: String::from("tests"),
+            branch: String::from("main"),
             repo,
             update_cmds: config.update
         }


### PR DESCRIPTION
## Description
This PR fixes an issue with the `watch` command when monitoring a branch different from the current one. Previously, the command always used the commit from the current branch instead of the selected branch.

## Changes made
- Updated `Repo::build()` to optionally accept a branch name:
  - If a branch name is provided, it uses that branch.
  - If no branch is provided, it defaults to the current branch.
  - If the specified branch does not exist, an error is returned.
- Updated tests to be compatible with the new `Repo::build()` signature and behavior.
- Added an installation script for easier setup.

These changes ensure that the `watch` command now correctly monitors the intended branch and that the tests run reliably both locally and in CI environments.
