### PR TITLE
Feature/cli env injection

### DIFF
--- a/fleet.yml
+++ b/fleet.yml
@@ -1,6 +1,6 @@
 ENV: &default_env
   SECRET_TOKEN: $
-  TEST_KEY: "non"
+  TEST_KEY: "oui"
 
 update:
   env: *default_env

--- a/fleet.yml
+++ b/fleet.yml
@@ -1,11 +1,11 @@
 ENV: &default_env
   SECRET_TOKEN: $
-  TEST_KEY: "oui"
+  TEST_KEY: "non"
 
 update:
   env: *default_env
   steps: 
-    - cmd: echo $SECRET_TOKEN
+    - cmd: env
     - cmd: ping google.com
       blocking: true
 

--- a/fleet.yml
+++ b/fleet.yml
@@ -1,7 +1,13 @@
+ENV: &default_env
+  SECRET_TOKEN: $
+  TEST_KEY: "oui"
+
 update:
-  - cmd: echo "oui je test"
-  - cmd: ping google.com
-    blocking: true
+  env: *default_env
+  steps: 
+    - cmd: echo $SECRET_TOKEN
+    - cmd: ping google.com
+      blocking: true
 
 on_confliot:
   - echo "un conflit est survenu"

--- a/src/app.rs
+++ b/src/app.rs
@@ -54,7 +54,7 @@ fn build_add_watch_request(
         project_dir: std::env::current_dir()?.to_string_lossy().into_owned(),
         branch,
         repo,
-        update_cmds: config.update.clone(),
+        update: config.update.clone(),
     })
 }
 

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -1,18 +1,26 @@
-use std::{fs, path::Path};
+use std::{collections::HashMap, fs, path::Path};
 
 use anyhow::{Context, Ok, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct UpdateCommand {
+    #[serde(default)]
     pub cmd: String,
     #[serde(default)]
     pub blocking: bool,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+pub struct UpdateSection {
+    #[serde(default)]
+    pub env: Option<HashMap<String, String>>,
+    pub steps: Vec<UpdateCommand>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct ProjectConfig {
-    pub update: Vec<UpdateCommand>,
+    pub update: UpdateSection,
 
     #[serde(default)]
     pub on_conflict: Vec<String>,
@@ -30,8 +38,18 @@ pub fn load_config(path: &Path) -> Result<ProjectConfig> {
     let content =
         fs::read_to_string(path).with_context(|| format!("Error reading config file {path:?}"))?;
 
-    let config: ProjectConfig =
+    let mut config: ProjectConfig =
         serde_yaml::from_str(&content).with_context(|| "Error parsing YAML configuration file")?;
+
+    if let Some(ref mut env_map) = config.update.env {
+        for (key, value) in env_map.iter_mut() {
+            if value == "$" {
+                *value = std::env::var(key).unwrap_or_else(|_| String::from(""));
+            }
+        }
+    }
+
+    println!("config => {:?}", config);
 
     Ok(config)
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 
 use crate::{
-    config::parser::{ProjectConfig, UpdateCommand},
+    config::parser::{ProjectConfig, UpdateSection},
     core::{
         id::short_id,
         state::{AppState, add_watch, get_id_by_name, get_name_by_id, remove_watch_by_id},
@@ -27,7 +27,7 @@ pub enum DaemonRequest {
         project_dir: String,
         branch: String,
         repo: Repo,
-        update_cmds: Vec<UpdateCommand>,
+        update: UpdateSection,
     },
 
     #[serde(rename = "stop_watch")]
@@ -99,8 +99,8 @@ pub async fn handle_request(
             project_dir,
             branch,
             repo,
-            update_cmds,
-        } => handle_add_watch(state, project_dir, branch, repo, update_cmds).await,
+            update,
+        } => handle_add_watch(state, project_dir, branch, repo, update).await,
 
         DaemonRequest::StopWatch { id } => handle_stop_watch(state, id).await,
 
@@ -124,7 +124,7 @@ async fn handle_add_watch(
     project_dir: String,
     branch: String,
     mut repo: Repo,
-    update_cmds: Vec<UpdateCommand>,
+    update: UpdateSection,
 ) -> DaemonResponse {
     let mut guard = state.watches.write().await;
     let existing_id = guard
@@ -143,7 +143,7 @@ async fn handle_add_watch(
         branch,
         repo,
         config: ProjectConfig {
-            update: update_cmds,
+            update,
             ..Default::default()
         },
         project_dir,

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -23,7 +23,7 @@ fn test_build_watch_request_branch_none() -> Result<(), Box<dyn std::error::Erro
             project_dir: std::env::current_dir()?.to_string_lossy().into_owned(),
             branch: repo.branch.clone(),
             repo,
-            update_cmds: config.update
+            update: config.update,
         }
     );
 
@@ -48,7 +48,7 @@ fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error::Erro
             project_dir: std::env::current_dir()?.to_string_lossy().into_owned(),
             branch: repo.branch.clone(),
             repo,
-            update_cmds: config.update
+            update: config.update,
         }
     );
 


### PR DESCRIPTION
# Add support for environment variables in `update` section

## Summary
This PR introduces a new structure for the `update` section in the YAML configuration file, allowing users to define environment variables once per update block and have them automatically injected into every step during execution.

## Configuration changes
Previously, each `update` command only supported `cmd` and `blocking` flags.  
Now, the `update` section supports an optional `env` field and a `steps` array, where each step contains a command and an optional blocking flag.

Example:
```yaml
update:
  env:
    DISCORD_TOKEN: $
    TEST_KEY: "yes"
  steps:
    - cmd: echo "Starting update"
    - cmd: git pull
````

- `$` is a special placeholder meaning:\
  *"Load the value from the CLI environment variables instead of the YAML file"*.
- Any other value will be used as a literal.

At runtime, each `cmd` in `steps` automatically receives the `env` variables defined in the parent `update` block.

## Code changes

1. **New data structure**

   - Introduced an `UpdateSection` struct containing:
     - `env`: `Option<HashMap<String, String>>` for per-update environment variables.
     - `steps`: `Vec<UpdateCommand>` holding the individual commands to execute.
   - `ProjectConfig.update` now uses `UpdateSection` instead of a plain list of commands.

2. **Environment variable resolution**

   - In `load_config`, any environment variable with the value `$` is resolved from the CLI process environment (`std::env::var`).
   - If not found, it defaults to an empty string.

3. **Execution logic**

   - At execution time, the environment map is injected into every command with `cmd.env(...)`.
   - This avoids repeating the same variables for each step.

## Benefits

- Cleaner YAML syntax with less repetition.
- Allows secure passing of CLI environment variables to the daemon without storing sensitive values in config files.
- Supports mixing static values and dynamically loaded ones.

