### PR TITLE
Fix/outside repo commands

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,19 +13,17 @@ use crate::{
 /// Handles watch-related CLI commands by delegating to subfunctions
 /// that build the appropriate [`DaemonRequest`].
 pub async fn handle_watch(cli: &Cli) -> Result<()> {
-    let repo = Repo::build(None)?;
-
-    let watch_req = build_watch_request(cli, repo)?;
+    let watch_req = build_watch_request(cli)?;
     send_watch_request(watch_req).await?;
     Ok(())
 }
 
 /// Builds the appropriate [`DaemonRequest`] for the given CLI command.
-pub fn build_watch_request(cli: &Cli, repo: Repo) -> Result<DaemonRequest> {
+pub fn build_watch_request(cli: &Cli) -> Result<DaemonRequest> {
     match &cli.command {
-        Commands::Watch { branch } => build_add_watch_request(branch.clone(), repo),
+        Commands::Watch { branch } => build_add_watch_request(branch.clone()),
         Commands::Ps { all } => Ok(DaemonRequest::ListWatches { all: *all }),
-        Commands::Logs { id_or_name } => Ok(build_logs_request(id_or_name, repo)),
+        Commands::Logs { id_or_name } => build_logs_request(id_or_name),
         Commands::Stop { id } => Ok(DaemonRequest::StopWatch { id: id.to_string() }),
         Commands::Up { id } => Ok(DaemonRequest::UpWatch { id: id.to_string() }),
         Commands::Rm { id } => Ok(DaemonRequest::RmWatch { id: id.to_string() }),
@@ -33,10 +31,7 @@ pub fn build_watch_request(cli: &Cli, repo: Repo) -> Result<DaemonRequest> {
 }
 
 /// Builds an [`AddWatch`] request after validating configuration.
-fn build_add_watch_request(
-    branch_cli: Option<String>,
-    default_repo: Repo,
-) -> Result<DaemonRequest> {
+fn build_add_watch_request(branch_cli: Option<String>) -> Result<DaemonRequest> {
     let config_path = Path::new("./fleet.yml");
     if !config_path.exists() {
         return Err(anyhow::anyhow!(
@@ -47,7 +42,7 @@ fn build_add_watch_request(
     let config = load_config(config_path)?;
     let branch = branch_cli
         .or(config.branch.clone())
-        .unwrap_or(default_repo.branch.clone());
+        .unwrap_or(Repo::build(None)?.branch.clone());
     let repo = Repo::build(Some(branch.clone()))?;
 
     Ok(DaemonRequest::AddWatch {
@@ -59,9 +54,12 @@ fn build_add_watch_request(
 }
 
 /// Builds a [`LogsWatches`] request from CLI or repository defaults.
-fn build_logs_request(id_or_name: &Option<String>, repo: Repo) -> DaemonRequest {
+fn build_logs_request(id_or_name: &Option<String>) -> Result<DaemonRequest> {
     match id_or_name {
-        Some(s) => DaemonRequest::LogsWatches { id: s.to_string() },
-        None => DaemonRequest::LogsWatches { id: repo.name },
+        Some(s) => Ok(DaemonRequest::LogsWatches { id: s.to_string() }),
+        None => {
+            let repo = Repo::build(None)?;
+            Ok(DaemonRequest::LogsWatches { id: repo.name })
+        }
     }
 }

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -49,7 +49,5 @@ pub fn load_config(path: &Path) -> Result<ProjectConfig> {
         }
     }
 
-    println!("config => {:?}", config);
-
     Ok(config)
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -16,7 +16,7 @@ fn test_build_watch_request_branch_none() -> Result<(), Box<dyn std::error::Erro
     let repo = Repo::build(None)?;
     let config = load_config(Path::new("./fleet.yml"))?;
 
-    let watch_req = build_watch_request(&cli, repo.clone())?;
+    let watch_req = build_watch_request(&cli)?;
     assert_eq!(
         watch_req,
         DaemonRequest::AddWatch {
@@ -41,7 +41,7 @@ fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error::Erro
 
     let config = load_config(Path::new("./fleet.yml"))?;
 
-    let watch_req = build_watch_request(&cli, repo.clone())?;
+    let watch_req = build_watch_request(&cli)?;
     assert_eq!(
         watch_req,
         DaemonRequest::AddWatch {


### PR DESCRIPTION
# Fix: Allow commands to run outside a repo

## Description

Previously, certain commands of the program could only be executed
inside a Git repository, even those that don't actually require repo context. 
This caused unexpected behavior when trying to use the tool globally.

This PR fixes the order of function calls and adjusts some logic
so that commands that do not require a repository can now be run anywhere.

## Impact

- Commands can now be safely run outside a Git repository
- No breaking changes to commands that require repo context
- Improves usability for global script execution

## Tests

- Verified running `your-command` outside a repo works as expected
- Ran all existing tests, all passed
- Verified that commands inside a repo still behave normally
![luffy-one-piece](https://github.com/user-attachments/assets/e6d0738d-a1a2-4cb5-a959-55d2f0b2f73c)

