### PR TITLE
feature: change logs behaviour to allow attached logs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -23,7 +23,7 @@ pub fn build_watch_request(cli: &Cli) -> Result<DaemonRequest> {
     match &cli.command {
         Commands::Watch { branch } => build_add_watch_request(branch.clone()),
         Commands::Ps { all } => Ok(DaemonRequest::ListWatches { all: *all }),
-        Commands::Logs { id_or_name } => build_logs_request(id_or_name),
+        Commands::Logs { id_or_name, follow } => build_logs_request(id_or_name, *follow),
         Commands::Stop { id } => Ok(DaemonRequest::StopWatch { id: id.to_string() }),
         Commands::Up { id } => Ok(DaemonRequest::UpWatch { id: id.to_string() }),
         Commands::Rm { id } => Ok(DaemonRequest::RmWatch { id: id.to_string() }),
@@ -54,12 +54,18 @@ fn build_add_watch_request(branch_cli: Option<String>) -> Result<DaemonRequest> 
 }
 
 /// Builds a [`LogsWatches`] request from CLI or repository defaults.
-fn build_logs_request(id_or_name: &Option<String>) -> Result<DaemonRequest> {
+fn build_logs_request(id_or_name: &Option<String>, follow: bool) -> Result<DaemonRequest> {
     match id_or_name {
-        Some(s) => Ok(DaemonRequest::LogsWatches { id: s.to_string() }),
+        Some(s) => Ok(DaemonRequest::LogsWatches {
+            id: s.to_string(),
+            f: follow,
+        }),
         None => {
             let repo = Repo::build(None)?;
-            Ok(DaemonRequest::LogsWatches { id: repo.name })
+            Ok(DaemonRequest::LogsWatches {
+                id: repo.name,
+                f: follow,
+            })
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,8 @@ pub enum Commands {
     },
 
     Logs {
+        #[arg(short = 'f', long)]
+        follow: bool,
         id_or_name: Option<String>,
     },
 }


### PR DESCRIPTION
This pull request adds support for following log output in real time when viewing logs for a watch, similar to the `tail -f` command. The main changes include updating the CLI to accept a `--follow` flag for logs, modifying the request and response structures to handle this new option, and implementing the logic on both the client and server sides to stream logs when requested.

**CLI and API changes:**
* Added a `follow` (`-f`/`--follow`) flag to the `Logs` command in `Commands` (`src/cli.rs`) to allow users to follow logs in real time.
* Updated the `DaemonRequest::LogsWatches` variant to include a `f` (follow) boolean, and modified all related request-building code to support this flag (`src/app.rs`, `src/ipc/server.rs`). [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L26-R26) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L57-R68) [[3]](diffhunk://#diff-6edddef98b196aa9bd3188ffb067d45a4eaf5f6d7e541b79ddc3322cb27fa9eaL47-R47) [[4]](diffhunk://#diff-6edddef98b196aa9bd3188ffb067d45a4eaf5f6d7e541b79ddc3322cb27fa9eaL114-R118) [[5]](diffhunk://#diff-6edddef98b196aa9bd3188ffb067d45a4eaf5f6d7e541b79ddc3322cb27fa9eaL270-R274)

**Daemon response and log streaming:**
* Added a new `DaemonResponse::LogWatch` variant containing the log file path and the follow flag, replacing the previous behavior of returning log contents directly (`src/ipc/server.rs`). [[1]](diffhunk://#diff-6edddef98b196aa9bd3188ffb067d45a4eaf5f6d7e541b79ddc3322cb27fa9eaR66) [[2]](diffhunk://#diff-6edddef98b196aa9bd3188ffb067d45a4eaf5f6d7e541b79ddc3322cb27fa9eaL280-R284)
* Refactored server-side log retrieval to return the log file path as a string, rather than the contents (`src/ipc/server.rs`).

**Client-side log display:**
* Implemented the `display_logs` function in the client to read and print the log file, either all at once or in a loop if following is requested, handling file-not-found errors and read errors gracefully (`src/ipc/client.rs`). [[1]](diffhunk://#diff-79763114640ad062f745fd0dd68f9197d6b4fba97fab21319b3ff2dc8d6c3b7bR1-R4) [[2]](diffhunk://#diff-79763114640ad062f745fd0dd68f9197d6b4fba97fab21319b3ff2dc8d6c3b7bL18-R22) [[3]](diffhunk://#diff-79763114640ad062f745fd0dd68f9197d6b4fba97fab21319b3ff2dc8d6c3b7bL34-R38) [[4]](diffhunk://#diff-79763114640ad062f745fd0dd68f9197d6b4fba97fab21319b3ff2dc8d6c3b7bR49-R82)

These changes together enable users to view logs for a watch and optionally follow them in real time, improving the usability of the log viewing feature.