### PR TITLE
Feature/cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/fleetd.rs"
 [dev-dependencies]
 pretty_assertions = "1.3" 
 
+[features]
+default = []
+force_commit = []
+
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/core/watcher.rs
+++ b/src/core/watcher.rs
@@ -6,6 +6,7 @@ use dirs::home_dir;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
+#[allow(unused_imports)]
 use crate::{
     config::parser::ProjectConfig,
     git::{remote::get_remote_branch_hash, repo::Repo},
@@ -60,16 +61,20 @@ impl WatchContext {
 }
 
 pub async fn watch_once(ctx: &WatchContext) -> Result<Option<String>, anyhow::Error> {
-    let remote_hash = get_remote_branch_hash(&ctx.repo.remote, &ctx.branch)?;
+    #[cfg(not(feature = "force_commit"))]
+    {
+        println!("JE RENTRE ICI");
+        let remote_hash = get_remote_branch_hash(&ctx.repo.remote, &ctx.branch)?;
 
-    if remote_hash != ctx.repo.last_commit {
-        println!(
-            "new commit detected: {} -> {}",
-            ctx.repo.last_commit, remote_hash
-        );
-        // run_update(ctx).await?;
-        // ctx.repo.last_commit = String::from(remote_hash);
-        return Ok(Some(remote_hash));
+        if remote_hash != ctx.repo.last_commit {
+            println!(
+                "new commit detected: {} -> {}",
+                ctx.repo.last_commit, remote_hash
+            );
+            return Ok(Some(remote_hash));
+        }
+        return Ok(None);
     }
-    Ok(None)
+    #[cfg(feature = "force_commit")]
+    return Ok(Some(ctx.repo.last_commit.clone()));
 }

--- a/src/exec/runner.rs
+++ b/src/exec/runner.rs
@@ -40,6 +40,10 @@ pub async fn run_update(ctx: &WatchContext) -> Result<(), anyhow::Error> {
         let args = &parts[1..];
         let env = ctx.config.update.env.clone();
 
+        if program == "git" && args[0] == "pull" {
+            println!("GIT PULL DETECTED");
+            panic!();
+        }
         if cmd_line.blocking {
             //blocking command => run in background and forget
             logger


### PR DESCRIPTION
This pull request introduces a new feature flag to control commit detection behavior and adds debugging output for certain git operations. The most important changes are grouped below by theme.

Feature flag for commit detection:

* Added a `force_commit` feature to `Cargo.toml` and implemented conditional logic in `watch_once` to always return the last commit when this feature is enabled, bypassing remote hash checks. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R21-R24) [[2]](diffhunk://#diff-d401c00032accc7ecd310aefb98b95093cc4ac30b34cb60d2cca96c48994529bR64-R79)
* Added an `#[allow(unused_imports)]` attribute to suppress warnings for unused imports in `src/core/watcher.rs`.