### PR TITLE
logs: now logs for timedout cmd are streamed

### DIFF
--- a/fleet.yml
+++ b/fleet.yml
@@ -10,6 +10,7 @@ pipeline:
   jobs:
     build:
       steps:
+        - cmd: cargo clean
         - cmd: cargo build
 
     test_rust:
@@ -17,14 +18,12 @@ pipeline:
       env:
         RUST_LOG: debug
       steps:
-        - cmd: cargo test --test cli_test
-          contaner: rust:1.89
+        - cmd: cargo test --test cli_test -- --test-threads=1
 
     echo_test:
       needs: [build]
       steps:
         - cmd: echo test 1
-          container: ubuntu:latest
 
     sleep_test:
       steps:
@@ -34,4 +33,3 @@ pipeline:
       needs: [test_rust, echo_test]
       steps:
         - cmd: echo je suis arriver a la fin
-          blocking: true


### PR DESCRIPTION
This pull request refactors the way command output is handled. The main change is that command stdout and stderr are now written directly to log files instead of being captured in memory and returned, which simplifies resource management and logging.
**Command output handling changes:**

* The `CommandOutput` struct no longer contains `stdout` and `stderr` fields; output is now written directly to log files using `OpenOptions` and `Stdio::from` in `run_command_with_timeout`, reducing memory usage and simplifying logging. [[1]](diffhunk://#diff-446edda5468abc1d1812945cc69ba973c308c5aa9a646122d693a70a1be202d6L6-L15) [[2]](diffhunk://#diff-446edda5468abc1d1812945cc69ba973c308c5aa9a646122d693a70a1be202d6R23-R37) [[3]](diffhunk://#diff-446edda5468abc1d1812945cc69ba973c308c5aa9a646122d693a70a1be202d6L49-R63) [[4]](diffhunk://#diff-446edda5468abc1d1812945cc69ba973c308c5aa9a646122d693a70a1be202d6L136-L148)