### PR TITLE
metrics: fix mem gesture (fixes #25)

### DIFF
--- a/fleet.yml
+++ b/fleet.yml
@@ -18,7 +18,6 @@ pipeline:
   jobs:
     build:
       steps:
-        - cmd: cargo clean
         - cmd: cargo build
 
     test_rust:

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -37,7 +37,7 @@ pub fn check_dependency_graph(config: &ProjectConfig) -> Result<()> {
             return Ok(());
         }
         if !temp.insert(name.to_string()) {
-            let cycle_start_index = path.iter().position(|n| n == name).unwrap_or(0);
+            let cycle_start_index: usize = path.iter().position(|n| n == name).unwrap_or(0);
             let cycle_path: Vec<_> = path[cycle_start_index..]
                 .iter()
                 .chain(std::iter::once(&name.to_string()))
@@ -89,7 +89,7 @@ pub fn load_config(path: &Path) -> Result<ProjectConfig> {
 
     check_dependency_graph(&config)?;
 
-    dbg!(&config);
+    // dbg!(&config);
 
     Ok(config)
 }

--- a/src/notifications/mod.rs
+++ b/src/notifications/mod.rs
@@ -1,1 +1,30 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
 pub mod sender;
+
+#[derive(Serialize)]
+pub struct DiscordField {
+    pub name: String,
+    pub value: String,
+    #[serde(default)]
+    pub inline: bool,
+}
+
+#[derive(Serialize)]
+pub struct DiscordFooter {
+    pub text: String,
+}
+
+#[derive(Serialize)]
+pub struct DiscordEmbed {
+    pub title: String,
+    pub description: String,
+    pub color: u32,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub fields: Vec<DiscordField>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub footer: Option<DiscordFooter>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub timestamp: Option<DateTime<Utc>>,
+}

--- a/src/notifications/sender.rs
+++ b/src/notifications/sender.rs
@@ -2,15 +2,15 @@ use anyhow::Result;
 use reqwest::Client;
 use serde_json::json;
 
-pub async fn discord_sender(url: &str, title: &str, description: &str, color: u32) -> Result<()> {
+use crate::{
+    core::watcher::WatchContext,
+    exec::metrics::ExecMetrics,
+    notifications::{DiscordEmbed, DiscordField, DiscordFooter},
+};
+
+pub async fn discord_sender(url: &str, embed: &DiscordEmbed) -> Result<()> {
     let payload = json!({
-        "embeds": [
-            {
-                "title": title,
-                "description": description,
-                "color": color
-            }
-        ]
+        "embeds": [embed]
     });
 
     let client = Client::new();
@@ -25,4 +25,66 @@ pub async fn discord_sender(url: &str, title: &str, description: &str, color: u3
             resp.text().await?
         ))
     }
+}
+
+pub async fn discord_send_succes(ctx: &WatchContext, m: &ExecMetrics) -> Result<()> {
+    let embed = DiscordEmbed {
+        title: "✅Pipeline finish".into(),
+        description: format!("Pipeline **{}** executed successfully", ctx.repo.name),
+        color: 0x2ECC71,
+        fields: vec![
+            DiscordField {
+                name: "Service name".into(),
+                value: format!("`{}`", ctx.repo.name.clone()),
+                inline: false,
+            },
+            DiscordField {
+                name: "Duration".into(),
+                value: format!("`{:.2}s`", (m.duration_ms.unwrap_or(1) as f64) / 1000.0),
+                inline: true,
+            },
+            DiscordField {
+                name: "CPU".into(),
+                value: format!("`{:.2}%`", m.cpu_usage),
+                inline: true,
+            },
+            DiscordField {
+                name: "Mem (%)".into(),
+                value: format!("`{:.2}%`", m.mem_usage),
+                inline: true,
+            },
+            DiscordField {
+                name: "Mem (Mb)".into(),
+                value: format!("`{}Mb`", m.mem_usage_kb / (1024 * 1024)),
+                inline: true,
+            },
+        ],
+        footer: Some(DiscordFooter {
+            text: "Fleet CI/CD Pipeline".into(),
+        }),
+        timestamp: Some(m.finished_at.unwrap()),
+    };
+    for c in ctx.config.pipeline.notifications.channels.iter() {
+        if c.service == "discord" {
+            discord_sender(&c.url, &embed).await?;
+        }
+    }
+    Ok(())
+}
+
+pub async fn discord_send_failure<E: std::error::Error>(ctx: &WatchContext, e: E) -> Result<()> {
+    let embed = DiscordEmbed {
+        title: "❌ Pipeline failed".into(),
+        description: format!("Error: {}", &e.to_string()),
+        color: 0xE74C3C,
+        fields: vec![],
+        footer: None,
+        timestamp: Some(chrono::Utc::now()),
+    };
+    for c in ctx.config.pipeline.notifications.channels.iter() {
+        if c.service == "discord" {
+            discord_sender(&c.url, &embed).await?;
+        }
+    }
+    Ok(())
 }

--- a/tests/scheduler_test.rs
+++ b/tests/scheduler_test.rs
@@ -513,46 +513,6 @@ async fn test_timeout_job() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_blocking_step() -> anyhow::Result<()> {
-    let jobs: HashMap<String, Job> = vec![
-        (
-            "job1".into(),
-            Job {
-                steps: vec![Cmd {
-                    cmd: "echo blocking".into(),
-                    blocking: true,
-                    container: None,
-                }],
-                needs: vec![],
-                env: None,
-            },
-        ),
-        (
-            "job2".into(),
-            Job {
-                steps: vec![Cmd {
-                    cmd: "echo after".into(),
-                    blocking: false,
-                    container: None,
-                }],
-                needs: vec![],
-                env: None,
-            },
-        ),
-    ]
-    .into_iter()
-    .collect();
-
-    let ctx = build_test_ctx("test_multiple_dependencies", jobs).await?;
-
-    run_pipeline(ctx.clone()).await.unwrap();
-    let log = fs::read_to_string(ctx.log_path())?;
-    assert_in_log_order(&log, "blocking", "after");
-    ctx.logger.clean().await?;
-    Ok(())
-}
-
-#[tokio::test]
 async fn test_multiple_dependencies() -> anyhow::Result<()> {
     let jobs: HashMap<String, Job> = vec![
         (
@@ -714,7 +674,7 @@ async fn test_failing_job_stops_pipeline() -> anyhow::Result<()> {
 
     let ctx = build_test_ctx("test_failing_job_stops_pipeline", jobs).await?;
     let result = run_pipeline(ctx.clone()).await;
-    dbg!(&result);
+    // dbg!(&result);
     assert!(result.is_err(), "Pipeline should fail");
     let log = fs::read_to_string(ctx.log_path())?;
     assert!(


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the metrics calculation and notification system, as well as some code cleanups. The main changes include a more detailed Discord notification system for pipeline status, improved memory usage tracking in metrics, and cleanup of test and debug code.

**Notifications System Improvements:**

* Refactored Discord notification logic: Added new types (`DiscordEmbed`, `DiscordField`, `DiscordFooter`) for richer Discord messages and replaced the previous notification functions with `discord_send_succes` and `discord_send_failure`, which send detailed pipeline status embeds to Discord channels. [[1]](diffhunk://#diff-eba8610210d9fa6aebdf912f5dadb694b69dde8f9353ea2abe3ce982efc001e3R1-R30) [[2]](diffhunk://#diff-096ca5f5915cd30893bde88219d81bdc8c85e1273407c348992ab765340c4e17L5-R13) [[3]](diffhunk://#diff-096ca5f5915cd30893bde88219d81bdc8c85e1273407c348992ab765340c4e17R29-R90) [[4]](diffhunk://#diff-273e3333c24f9d9623c4769375a31900175bbfa6ed0479c5b1f9733d4483cb6fL19-R19) [[5]](diffhunk://#diff-273e3333c24f9d9623c4769375a31900175bbfa6ed0479c5b1f9733d4483cb6fL187-R187) [[6]](diffhunk://#diff-273e3333c24f9d9623c4769375a31900175bbfa6ed0479c5b1f9733d4483cb6fL213-R200)

**Metrics Calculation and Data Model:**

* Improved memory usage tracking: Changed `mem_usage_kb` from `f32` to `u64` for more accurate tracking, added a separate `mem_usage` field (percentage), and updated all related calculations and data structures (`JobMetrics`, `ExecMetrics`, `ProjectMetrics`, `ProjectStats`). [[1]](diffhunk://#diff-ac440e87f118e64992867fe77979968383b1c516a798cb6d39136d4e009cd625L33-R34) [[2]](diffhunk://#diff-ac440e87f118e64992867fe77979968383b1c516a798cb6d39136d4e009cd625L50-R52) [[3]](diffhunk://#diff-ac440e87f118e64992867fe77979968383b1c516a798cb6d39136d4e009cd625L69-R72) [[4]](diffhunk://#diff-ac440e87f118e64992867fe77979968383b1c516a798cb6d39136d4e009cd625L91-R127) [[5]](diffhunk://#diff-ac440e87f118e64992867fe77979968383b1c516a798cb6d39136d4e009cd625L139-R145) [[6]](diffhunk://#diff-ac440e87f118e64992867fe77979968383b1c516a798cb6d39136d4e009cd625R165-R167) [[7]](diffhunk://#diff-ac440e87f118e64992867fe77979968383b1c516a798cb6d39136d4e009cd625L169-R179) [[8]](diffhunk://#diff-7a7f85726f317e6cf291ac4c9f3a23861818ce755264ca4b9169a75c58bac9bdL35-R36) [[9]](diffhunk://#diff-7a7f85726f317e6cf291ac4c9f3a23861818ce755264ca4b9169a75c58bac9bdR48-R50) [[10]](diffhunk://#diff-7a7f85726f317e6cf291ac4c9f3a23861818ce755264ca4b9169a75c58bac9bdL187-R198) [[11]](diffhunk://#diff-7a7f85726f317e6cf291ac4c9f3a23861818ce755264ca4b9169a75c58bac9bdR208-R210)

**Code Cleanup and Testing:**

* Removed unnecessary debug output and outdated tests: Commented out `dbg!` statements and removed the `test_blocking_step` test to clean up the codebase. [[1]](diffhunk://#diff-fe0533b7fb6689b2c6c973510eb5bd71e2a04f717832b7f0b3b5d66028b82958L92-R92) [[2]](diffhunk://#diff-ed059d1b345d1611362dcc9c1746dc87c8b23eb42ef57b83d5bb97a00b694dc0L515-L554) [[3]](diffhunk://#diff-ed059d1b345d1611362dcc9c1746dc87c8b23eb42ef57b83d5bb97a00b694dc0L717-R677)

**Other Minor Improvements:**

* Changed metrics file writing to truncate and overwrite rather than append, ensuring only the latest metrics are stored.