### PR TITLE
ci: activate the 'test' job only on commit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,58 @@
 # Copilot Instructions – Pull Request Descriptions
 
-- When generating a PR description, always include a small "Before / After" example to illustrate behavior changes or new features.
-- Present new features as bullet points with a clear, descriptive title.
-- For each behavior change, briefly describe the effect before and after.
-- Be clear, concise, and developer-oriented.
+## Goal
+When generating a Pull Request description, provide a clear, developer-oriented summary with consistent formatting.
+
+## Expected Structure
+
+1. **Summary**
+   - One or two sentences explaining the purpose of the PR.
+
+2. **Changes**
+   - Use bullet points.
+   - Each item should have a clear title followed by a short explanation.
+
+3. **Before / After Examples**
+   - Always include minimal examples to illustrate behavior changes or new features.
+   - Examples must be shown in fenced code blocks.
+   - Two acceptable formats:
+
+   ### A. Full Code Snippets
+   ```markdown
+   ### Before
+   ```json
+   {
+     "host": "localhost",
+     "port": 5432
+   }
+   ```
+
+   ### After
+   ```json
+   {
+     "host": "localhost",
+     "port": 5432,
+     "username": "admin"
+   }
+   ```
+   ```
+
+   ### B. Clean Diff
+   ```diff
+   {
+     "host": "localhost",
+     "port": 5432
+   -}
+   +, "username": "admin"}
+   ```
+   - Allowed: `+` and `-` to indicate additions/removals.  
+   - Not allowed: diffhunks (`@@ ... @@`) or truncated context.
+
+4. **Notes**
+   - If the change has special implications (migrations, dependencies, compatibility issues), add a *Notes* section.
+
+## Style
+- Be concise and to the point.
+- Avoid long sentences or unnecessary explanations.
+- Always show examples inside code blocks.
+- **Never use `@@` diffhunks or omit relevant lines. Show the minimal but complete change.**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
       - name: Cache Cargo dependencies


### PR DESCRIPTION
This pull request updates project documentation and CI configuration to improve clarity and workflow reliability. The most important changes include a major revision to the PR description instructions for consistency and developer focus, and a conditional for running CI tests only on push events.

**Documentation improvements:**

* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L3-R58): Rewrote the PR description instructions to enforce a consistent structure, including a summary, bullet-pointed changes, mandatory before/after code examples in fenced blocks, and a notes section for special implications. Style guidelines were clarified for conciseness and completeness.

**CI workflow changes:**

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR39): Added a conditional to the test job so it only runs on push events, preventing unnecessary test runs on other event types.