### PR TITLE
fix: now fleet support ed25519 in addition to RSA (fixes #32)

### DIFF
--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -1,22 +1,37 @@
 #![allow(dead_code)]
+use std::path::PathBuf;
+
 use dirs::home_dir;
 use git2::{Cred, Error, Remote, RemoteCallbacks};
+
+fn find_ssh_key() -> Result<PathBuf, Error> {
+    let keys_name = vec![String::from("id_ed25519"), String::from("id_rsa")];
+    for k in keys_name {
+        let ssh_key_path = home_dir()
+            .map(|h| h.join(".ssh/").join(k))
+            .expect("Failed to find HOME directory");
+        if ssh_key_path.exists() {
+            return Ok(ssh_key_path);
+        }
+    }
+    Err(git2::Error::from_str(
+        "Failed to find ssh_key on your machine :/",
+    ))
+}
 
 pub fn get_remote_branch_hash(url: &str, branch: &str) -> Result<String, Error> {
     let mut callbacks = RemoteCallbacks::new();
 
     callbacks.credentials(|_url, username_from_url, allowed_types| {
         let username = username_from_url.unwrap_or("git");
-        let ssh_key_path = home_dir()
-            .map(|h| h.join(".ssh/id_rsa"))
-            .expect("Failed to find HOME directory");
+        let ssh_key_path = find_ssh_key()?;
 
-        // Try default key locations (~/.ssh/id_rsa)
         if allowed_types.contains(git2::CredentialType::SSH_KEY)
             && let Ok(cred) = Cred::ssh_key(username, None, &ssh_key_path, None)
         {
             return Ok(cred);
         }
+
         // Try default credentials
         if allowed_types.contains(git2::CredentialType::DEFAULT)
             && let Ok(cred) = Cred::default()


### PR DESCRIPTION
This pull request enhances the SSH authentication logic in the `src/git/remote.rs` file to improve compatibility with different SSH key types. The main change is the addition of a helper function to search for both `id_ed25519` and `id_rsa` SSH keys, instead of hardcoding a single key type.

**SSH Key Detection Improvements:**

* Added a new `find_ssh_key` function to search for both `id_ed25519` and `id_rsa` keys in the user's `~/.ssh/` directory, improving support for multiple SSH key types.
* Updated the credentials callback in `get_remote_branch_hash` to use the new `find_ssh_key` function, making SSH authentication more robust and user-friendly.