### PR TITLE
Features/trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ fleet watch
 | `fleet up <id>`         | Resume watching a stopped project                                                      |
 | `fleet rm <id>`         | Remove a monitored project                                                             |
 | `fleet stats`           | Show interactive statistics of all watched projects                                    |
+| `fleet run <id>`        | Run a pipeline on demand                                                               |
 
 ---
 

--- a/fleet.yml
+++ b/fleet.yml
@@ -14,28 +14,19 @@ pipeline:
     channels:
       - service: discord
         url: https://discord.com/api/webhooks/1411403673028001989/WH1KIMmgxSNEF6kV_9-TQS1LadHASBLDJ5evPgMIo3Ko8NX40hcMom_InEo9YsNrRDmu
+  
   jobs:
-    build:
-      steps:
-        - cmd: cargo build
-
     test_rust:
-      needs: [build]
       env:
         RUST_LOG: debug
       steps:
         - cmd: cargo test --test cli_test -- --test-threads=1
-
-    echo_test:
-      pipe: test_rust
-      steps:
-        - cmd: grep ok
 
     sleep_test:
       steps:
         - cmd: sleep 5
         
     deploy:
-      needs: [test_rust, echo_test]
+      needs: [test_rust]
       steps:
         - cmd: echo je suis arriver a la fin

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,6 +32,7 @@ pub async fn build_watch_request(cli: &Cli) -> Result<DaemonRequest> {
             display_stats_interface().await?;
             Ok(DaemonRequest::None)
         }
+        Commands::Run { id } => Ok(DaemonRequest::RunPipeline { id: id.clone() }),
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,9 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum Commands {
+    Run {
+        id: String,
+    },
     Watch {
         #[arg(short = 'b', long, default_value = None)]
         branch: Option<String>,

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -77,7 +77,7 @@ async fn update_commit(state: &Arc<AppState>, id: &str, new_commit: String) {
     }
 }
 
-async fn get_watch_ctx(state: &Arc<AppState>, id: &str) -> Option<WatchContext> {
+pub async fn get_watch_ctx(state: &Arc<AppState>, id: &str) -> Option<WatchContext> {
     let watches_read: tokio::sync::RwLockReadGuard<
         '_,
         std::collections::HashMap<String, WatchContext>,

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -52,7 +52,7 @@ fn handle_daemon_response(response: DaemonResponse) -> Result<()> {
         DaemonResponse::LogWatch(p, f) => {
             display_logs(&p, f)?;
         }
-        DaemonResponse::None => {}
+        DaemonResponse::None | DaemonResponse::Ignore => {}
     }
     Ok(())
 }

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -5,9 +5,11 @@ use crate::{
     config::ProjectConfig,
     core::{
         id::short_id,
+        manager::get_watch_ctx,
         state::{AppState, add_watch, get_id_by_name, get_name_by_id, remove_watch_by_id},
         watcher::{WatchContext, WatchContextBuilder},
     },
+    exec::runner::run_pipeline,
     git::repo::Repo,
     ipc::utiles::extract_repo_path,
     logging::Logger,
@@ -30,6 +32,11 @@ pub enum DaemonRequest {
         // use Box (clippy)
         repo: Box<Repo>,
         config: Box<ProjectConfig>,
+    },
+
+    #[serde(rename = "run_pipeline")]
+    RunPipeline {
+        id: String,
     },
 
     #[serde(rename = "stop_watch")]
@@ -61,7 +68,7 @@ pub enum DaemonRequest {
     None,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct WatchInfo {
     pub branch: String,
     pub project_dir: String,
@@ -72,12 +79,13 @@ pub struct WatchInfo {
     pub paused: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum DaemonResponse {
     Success(String),
     Error(String),
     ListWatches(Vec<WatchInfo>),
     LogWatch(String, bool),
+    Ignore,
     None,
 }
 
@@ -130,10 +138,39 @@ pub async fn handle_request(
 
         DaemonRequest::LogsWatches { id, f } => handle_logs_watches(id, f).await,
 
+        DaemonRequest::RunPipeline { id } => {
+            handle_run_pipeline(&id, state, stream).await?;
+            DaemonResponse::Ignore
+        }
         DaemonRequest::None => DaemonResponse::None,
     };
 
-    send_response(stream, response).await?;
+    if response != DaemonResponse::Ignore {
+        send_response(stream, response).await?;
+    }
+    Ok(())
+}
+
+async fn handle_run_pipeline(
+    id: &str,
+    state: Arc<AppState>,
+    stream: &mut WriteHalf<UnixStream>,
+) -> anyhow::Result<()> {
+    if let Some(ctx) = get_watch_ctx(&state, id).await {
+        send_response(
+            stream,
+            DaemonResponse::Success(format!("Pipeline {id} has been runed")),
+        )
+        .await?;
+        match run_pipeline(Arc::new(ctx)).await {
+            Ok(_) => {
+                println!("[{id}] ✅ Update succeeded");
+            }
+            Err(e) => {
+                eprintln!("[{id}] ❌ Update failed => {e}");
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src/notifications/sender.rs
+++ b/src/notifications/sender.rs
@@ -13,8 +13,6 @@ pub async fn discord_sender(url: &str, embed: &DiscordEmbed) -> Result<()> {
         "embeds": [embed]
     });
 
-    println!("debug: embed: {:#?}", embed);
-
     let client = Client::new();
     let resp = client.post(url).json(&payload).send().await?;
 


### PR DESCRIPTION
This pull request introduces a new feature that allows users to run a pipeline on demand for a monitored project, along with supporting changes to the CLI, server, and configuration. It also includes some minor codebase improvements and refactoring for better code clarity and maintainability.

**New pipeline execution feature:**

* Added a new `fleet run <id>` CLI command and corresponding help documentation in `README.md` to allow users to trigger a pipeline run for a specific project on demand. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90) [[2]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR12-R14)
* Implemented support for the `RunPipeline` request type in the IPC server, including handling logic and response management in `src/ipc/server.rs`. [[1]](diffhunk://#diff-6edddef98b196aa9bd3188ffb067d45a4eaf5f6d7e541b79ddc3322cb27fa9eaR37-R41) [[2]](diffhunk://#diff-6edddef98b196aa9bd3188ffb067d45a4eaf5f6d7e541b79ddc3322cb27fa9eaR141-R173) [[3]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R35)
* Exposed `get_watch_ctx` as a public function to retrieve the context needed to run a pipeline for a project.

**Codebase improvements and refactoring:**

* Updated the pipeline configuration in `fleet.yml` to remove unused jobs and adjust dependencies, streamlining the workflow.
* Refactored response handling to support an `Ignore` response type, improving the server's response logic and preventing unnecessary responses. [[1]](diffhunk://#diff-6edddef98b196aa9bd3188ffb067d45a4eaf5f6d7e541b79ddc3322cb27fa9eaL75-R88) [[2]](diffhunk://#diff-79763114640ad062f745fd0dd68f9197d6b4fba97fab21319b3ff2dc8d6c3b7bL55-R55)
* Minor improvements: removed debug print statements from the Discord notification sender for cleaner logs.