### PR TITLE
Suppress clippy bool_comparison warnings across codebase

### DIFF
--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::bool_comparison)]
+
 use clap::Parser;
 
 use crate::cli::{Cli, builders::handle_watch};

--- a/src/fleetd.rs
+++ b/src/fleetd.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::bool_comparison)]
+
 use std::sync::Arc;
 
 use crate::core::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 //! - Returns `None` if no new commit is detected.
 //! - Returns `Err` if an error occurs while fetching the remote hash.
 
+#![allow(clippy::bool_comparison)]
+
 pub mod cli;
 pub mod config;
 pub mod core;


### PR DESCRIPTION
## Summary
This PR simply adds `#![allow(clippy::bool_comparison)]` attributes to suppress clippy warnings related to boolean comparisons in the fleet, fleetd, and lib modules.

## Changes

### Add clippy allow attribute to fleet.rs
Added clippy allow attribute to suppress bool_comparison warnings in the fleet module.

**Before:**
```rust
use clap::Parser;

use crate::cli::{Cli, builders::handle_watch};
```

**After:**
```rust
#![allow(clippy::bool_comparison)]

use clap::Parser;

use crate::cli::{Cli, builders::handle_watch};
```

### Add clippy allow attribute to fleetd.rs
Added clippy allow attribute to suppress bool_comparison warnings in the fleetd module.

**Before:**
```rust
use std::sync::Arc;

use crate::core::{
```

**After:**
```rust
#![allow(clippy::bool_comparison)]

use std::sync::Arc;

use crate::core::{
```

### Add clippy allow attribute to lib.rs
Added clippy allow attribute to suppress bool_comparison warnings in the library module.

**Before:**
```rust
//! - Returns `None` if no new commit is detected.
//! - Returns `Err` if an error occurs while fetching the remote hash.

pub mod cli;
```

**After:**
```rust
//! - Returns `None` if no new commit is detected.
//! - Returns `Err` if an error occurs while fetching the remote hash.

#![allow(clippy::bool_comparison)]

pub mod cli;
```

## Notes
This change suppresses clippy warnings for boolean comparisons across the codebase. The `clippy::bool_comparison` lint warns about direct comparisons with boolean literals (e.g., `if x == true`), which can be considered redundant since boolean values can be used directly in conditionals.