### PR TITLE
Refactor/branch rework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Clear files      
         run: rm -rf ~/.local/share/fleetd
       - name: Run cargo test 
-        run: cargo test --test utiles_test --test cli_test --test daemon_test --  --test-threads=1
+        run: cargo test --test utiles_test --test git_test --test cli_test --test daemon_test --  --test-threads=1
 
   build:
     name: Build project

--- a/fleet.yml
+++ b/fleet.yml
@@ -30,5 +30,6 @@ pipeline:
         
     deploy:
       needs: [test_rust]
+      env: *default_env
       steps:
         - cmd: echo je suis arriver a la fin

--- a/fleet.yml
+++ b/fleet.yml
@@ -4,6 +4,7 @@ ENV: &default_env
   SECRET_TOKEN: $
   TEST_KEY: "oui"
 
+branches: ['*']
 
 timeout: 200
 

--- a/fleet.yml
+++ b/fleet.yml
@@ -4,6 +4,7 @@ ENV: &default_env
   SECRET_TOKEN: $
   TEST_KEY: "oui"
 
+
 timeout: 200
 
 pipeline:

--- a/fleet.yml
+++ b/fleet.yml
@@ -30,6 +30,5 @@ pipeline:
         
     deploy:
       needs: [test_rust]
-      env: *default_env
       steps:
         - cmd: echo je suis arriver a la fin

--- a/src/cli/builders.rs
+++ b/src/cli/builders.rs
@@ -46,16 +46,24 @@ fn build_add_watch_request() -> Result<DaemonRequest> {
     let config = load_config(config_path)?;
 
     let (branches, b_name) = if config.branches[0] == "*" {
-        (branch_wildcard()?, "*".to_string())
+        (branch_wildcard()?, "*".to_string()) // if is wildcard branch we use '*' as branch name
     } else {
-        (config.branches.clone(), config.branches[0].clone())
+        // else if is one or more branch we use the last branch name
+        // e.g: ["main", "test", "abc"] -> b_name will be "abc"
+        (
+            config.branches.clone(),
+            config
+                .branches
+                .last()
+                .unwrap_or(&config.branches[0])
+                .clone(),
+        )
     };
-
-    println!("debug: branches: {:#?}", branches);
 
     let mut repo = Repo::build(branches.clone())?;
 
-    repo.branches.name = b_name;
+    repo.branches.name = b_name; //  asigne default name
+    repo.branches.last_commit = repo.branches.default_last_commit()?;
     println!("debug: repo branches: {:#?}", repo.branches);
 
     Ok(DaemonRequest::AddWatch {

--- a/src/cli/builders.rs
+++ b/src/cli/builders.rs
@@ -3,11 +3,10 @@ use std::path::Path;
 use anyhow::{Ok, Result};
 
 use crate::{
-    cli::stats::interface::display_stats_interface,
-    cli::{Cli, Commands, client::send_watch_request},
+    cli::{Cli, Commands, client::send_watch_request, stats::interface::display_stats_interface},
     config::parser::load_config,
     daemon::server::DaemonRequest,
-    git::repo::Repo,
+    git::{remote::branch_wildcard, repo::Repo},
 };
 
 /// Handles watch-related CLI commands by delegating to subfunctions
@@ -21,7 +20,7 @@ pub async fn handle_watch(cli: &Cli) -> Result<()> {
 /// Builds the appropriate [`DaemonRequest`] for the given CLI command.
 pub async fn build_watch_request(cli: &Cli) -> Result<DaemonRequest> {
     match &cli.command {
-        Commands::Watch { branch } => build_add_watch_request(branch.clone()),
+        Commands::Watch => build_add_watch_request(),
         Commands::Ps { all } => Ok(DaemonRequest::ListWatches { all: *all }),
         Commands::Logs { id_or_name, follow } => build_logs_request(id_or_name, *follow),
         Commands::Stop { id } => Ok(DaemonRequest::StopWatch { id: id.to_string() }),
@@ -36,7 +35,7 @@ pub async fn build_watch_request(cli: &Cli) -> Result<DaemonRequest> {
 }
 
 /// Builds an [`AddWatch`] request after validating configuration.
-fn build_add_watch_request(branch_cli: Option<String>) -> Result<DaemonRequest> {
+fn build_add_watch_request() -> Result<DaemonRequest> {
     let config_path = Path::new("./fleet.yml");
     if !config_path.exists() {
         return Err(anyhow::anyhow!(
@@ -46,24 +45,21 @@ fn build_add_watch_request(branch_cli: Option<String>) -> Result<DaemonRequest> 
 
     let config = load_config(config_path)?;
 
-    // let branch = branch_cli
-    //     .or(config.branches.clone())
-    //     .unwrap_or(Repo::build(None)?.branch.clone());
-
-    let branches = if let Some(b) = config.branches.clone() {
-        b
+    let (branches, b_name) = if config.branches[0] == "*" {
+        (branch_wildcard()?, "*".to_string())
     } else {
-        if let Some(b) = branch_cli {
-            vec![b]
-        } else {
-            anyhow::bail!("No branch found");
-        }
+        (config.branches.clone(), config.branches[0].clone())
     };
-    let repo = Repo::build(branches.clone())?;
+
+    println!("debug: branches: {:#?}", branches);
+
+    let mut repo = Repo::build(branches.clone())?;
+
+    repo.branches.name = b_name;
+    println!("debug: repo branches: {:#?}", repo.branches);
 
     Ok(DaemonRequest::AddWatch {
         project_dir: std::env::current_dir()?.to_string_lossy().into_owned(),
-        branches,
         repo: Box::new(repo),
         config: Box::new(config),
     })

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,11 +18,7 @@ pub enum Commands {
     Run {
         id: String,
     },
-    Watch {
-        #[arg(short = 'b', long, default_value = None)]
-        branch: Option<String>,
-    },
-
+    Watch,
     Ps {
         #[arg(short = 'a', long)]
         all: bool,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -37,7 +37,7 @@ pub struct ProjectConfig {
     pub pipeline: Pipeline,
 
     #[serde(default)]
-    pub branch: Option<String>,
+    pub branches: Option<Vec<String>>,
 
     #[serde(default)]
     pub timeout: Option<u64>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -36,8 +36,7 @@ pub struct Pipeline {
 pub struct ProjectConfig {
     pub pipeline: Pipeline,
 
-    #[serde(default)]
-    pub branches: Option<Vec<String>>,
+    pub branches: Vec<String>,
 
     #[serde(default)]
     pub timeout: Option<u64>,

--- a/src/config/parser.rs
+++ b/src/config/parser.rs
@@ -70,7 +70,7 @@ pub fn check_dependency_graph(config: &ProjectConfig) -> Result<()> {
 }
 
 pub fn load_config(path: &Path) -> Result<ProjectConfig> {
-    let content =
+    let content: String =
         fs::read_to_string(path).with_context(|| format!("Error reading config file {path:?}"))?;
 
     let mut config: ProjectConfig =

--- a/src/core/id.rs
+++ b/src/core/id.rs
@@ -5,3 +5,11 @@ pub fn short_id() -> String {
     OsRng.fill_bytes(&mut bytes);
     hex::encode(bytes)[..12].to_string()
 }
+
+pub fn format_commit(commit: &str) -> String {
+    if commit.len() > 10 {
+        commit[..10].to_string()
+    } else {
+        commit.to_string()
+    }
+}

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -9,6 +9,7 @@ use tokio::{
 
 use crate::{
     core::{
+        id::format_commit,
         state::AppState,
         watcher::{WatchContext, watch_once},
     },
@@ -59,10 +60,17 @@ async fn collect_updates(state: &Arc<AppState>) -> Vec<(String, String)> {
         }
 
         // TODO: take Branch in arg for watch_once() branch has to be stored in ctx.config.branches
-        println!("yes");
         match watch_once(&mut ctx.repo) {
             Ok(Some(new_commit)) => {
                 println!("[{id}] ✔ OK");
+                ctx.logger
+                    .info(&format!(
+                        "New commit [{}] from branch {}",
+                        format_commit(&ctx.repo.branches.last_commit),
+                        ctx.repo.branches.last_name
+                    ))
+                    .await
+                    .ok(); // ignore log fail
                 to_update.push((id.clone(), new_commit));
             }
             Ok(None) => {}

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     daemon::server::{DaemonRequest, handle_request},
     exec::pipeline::run_pipeline,
+    git::repo::Repo,
 };
 
 #[doc = include_str!("docs/supervisor_loop.md")]
@@ -71,6 +72,8 @@ async fn collect_updates(state: &Arc<AppState>) -> Vec<(String, String)> {
                     ))
                     .await
                     .ok(); // ignore log fail
+                //for the moment i ignore the error but in the futur i have to handle it correctly
+                Repo::switch_branch(ctx, &ctx.repo.branches.last_name).ok();
                 to_update.push((id.clone(), new_commit));
             }
             Ok(None) => {}

--- a/src/core/watcher.rs
+++ b/src/core/watcher.rs
@@ -123,5 +123,5 @@ pub fn watch_once(repo: &mut Repo) -> Result<Option<String>, anyhow::Error> {
         Ok(first_new)
     }
     #[cfg(feature = "force_commit")]
-    return Ok(Some(ctx.repo.last_commit.clone()));
+    return Ok(Some(repo.branches.last_commit.clone()));
 }

--- a/src/core/watcher.rs
+++ b/src/core/watcher.rs
@@ -8,7 +8,7 @@ use tokio::fs;
 
 #[allow(unused_imports)]
 use crate::git::{remote::get_remote_branch_hash, repo::Repo};
-use crate::{config::ProjectConfig, log::logger::Logger};
+use crate::{config::ProjectConfig, git::repo::Branch, log::logger::Logger};
 
 #[doc = include_str!("docs/watch_context.md")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -114,15 +114,15 @@ impl WatchContext {
 }
 
 #[doc = include_str!("docs/watch_once.md")]
-pub async fn watch_once(ctx: &WatchContext) -> Result<Option<String>, anyhow::Error> {
+pub async fn watch_once(branch: &Branch) -> Result<Option<String>, anyhow::Error> {
     #[cfg(not(feature = "force_commit"))]
     {
-        let remote_hash = get_remote_branch_hash(&ctx.repo.remote, &ctx.branch)?;
+        let remote_hash = get_remote_branch_hash(&branch.remote, &branch.name)?;
 
-        if remote_hash != ctx.repo.last_commit {
+        if remote_hash != branch.last_commit {
             println!(
                 "new commit detected: {} -> {}",
-                ctx.repo.last_commit, remote_hash
+                branch.last_commit, remote_hash
             );
             return Ok(Some(remote_hash));
         }

--- a/src/core/watcher.rs
+++ b/src/core/watcher.rs
@@ -119,7 +119,6 @@ pub fn watch_once(repo: &mut Repo) -> Result<Option<String>, anyhow::Error> {
         })?;
 
         let first_new = res.into_iter().flatten().next();
-        println!(" debug : first new : {:#?}", first_new);
         Ok(first_new)
     }
     #[cfg(feature = "force_commit")]

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -29,7 +29,7 @@ pub enum DaemonRequest {
     #[serde(rename = "add_watch")]
     AddWatch {
         project_dir: String,
-        branch: String,
+        branches: Vec<String>,
         // use Box (clippy)
         repo: Box<Repo>,
         config: Box<ProjectConfig>,

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -10,8 +10,7 @@ use crate::{
         watcher::{WatchContext, WatchContextBuilder},
     },
     daemon::utiles::extract_repo_path,
-    exec::metrics::ExecMetrics,
-    exec::pipeline::run_pipeline,
+    exec::{metrics::ExecMetrics, pipeline::run_pipeline},
     git::repo::Repo,
     log::logger::Logger,
 };
@@ -29,7 +28,6 @@ pub enum DaemonRequest {
     #[serde(rename = "add_watch")]
     AddWatch {
         project_dir: String,
-        branches: Vec<String>,
         // use Box (clippy)
         repo: Box<Repo>,
         config: Box<ProjectConfig>,
@@ -124,10 +122,9 @@ pub async fn handle_request(
     let response = match req {
         DaemonRequest::AddWatch {
             project_dir,
-            branch,
             repo,
             config,
-        } => handle_add_watch(state, project_dir, branch, *repo, *config).await?,
+        } => handle_add_watch(state, project_dir, *repo, *config).await?,
 
         DaemonRequest::StopWatch { id } => handle_stop_watch(state, id).await,
 
@@ -180,24 +177,18 @@ async fn handle_run_pipeline(
 async fn handle_add_watch(
     state: Arc<AppState>,
     project_dir: String,
-    branch: String,
-    mut repo: Repo,
+    repo: Repo,
     config: ProjectConfig,
 ) -> anyhow::Result<DaemonResponse> {
     let mut guard = state.watches.write().await;
     let existing_id = guard
         .iter()
         .find(|(_, ctx)| ctx.project_dir == project_dir)
-        .map(|(id, ctx)| {
-            if ctx.repo.branch != branch {
-                repo.last_commit = ctx.repo.last_commit.clone();
-            }
-            id.clone()
-        });
+        .map(|(id, _ctx)| id.clone());
 
     let id = existing_id.unwrap_or_else(short_id);
 
-    let ctx = WatchContextBuilder::new(branch, repo, config, project_dir, id.clone())
+    let ctx = WatchContextBuilder::new(repo, config, project_dir, id.clone())
         .build()
         .await?;
 
@@ -290,12 +281,18 @@ pub async fn handle_list_watches(state: Arc<AppState>, all: bool) -> DaemonRespo
             .iter()
             .filter(|(_, ctx)| all || !ctx.paused) // if all = true everything pass, else only if paused is false they can pass
             .map(|(id, ctx)| {
-                let short_commit = ctx.repo.last_commit.chars().take(8).collect::<String>();
+                let short_commit = ctx
+                    .repo
+                    .branches
+                    .last_commit
+                    .chars()
+                    .take(8)
+                    .collect::<String>();
                 let short_url = extract_repo_path(&ctx.repo.remote)?;
-                let short_branch = if ctx.branch.len() > 12 {
-                    format!("{}...", &ctx.branch[..9])
+                let short_branch = if ctx.repo.branches.name.len() > 12 {
+                    format!("{}...", &ctx.repo.branches.name[..9])
                 } else {
-                    ctx.branch.clone()
+                    ctx.repo.branches.name.clone()
                 };
                 Ok(WatchInfo {
                     branch: short_branch,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,2 +1,3 @@
+#![allow(dead_code)]
 pub mod remote;
 pub mod repo;

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -53,10 +53,25 @@ pub fn get_remote_branch_hash(url: &str, branch: &str) -> Result<String, Error> 
     remote.connect_auth(git2::Direction::Fetch, Some(callbacks), None)?;
 
     let refs = remote.list()?;
-    let ref_to_find = format!("refs/heads/{branch}");
+    // let ref_to_find = format!("refs/heads/{branch}");
 
+    // for r in refs {
+    //     if r.name() == ref_to_find {
+    //         return Ok(r.oid().to_string());
+    //     }
+    // }
+
+    let branch_name = if branch.starts_with("origin/") {
+        &branch["origin/".len()..]
+    } else {
+        branch
+    };
+
+    println!("debug: branch in remote fn : {branch_name}");
     for r in refs {
-        if r.name() == ref_to_find {
+        let name = r.name();
+        println!("debug: r.name() : {name}");
+        if name.ends_with(branch_name) {
             return Ok(r.oid().to_string());
         }
     }

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use dirs::home_dir;
 use git2::{BranchType, Cred, Error, Remote, RemoteCallbacks, Repository};
 
-fn find_ssh_key() -> Result<PathBuf, Error> {
+pub fn find_ssh_key() -> Result<PathBuf, Error> {
     let keys_name = vec![String::from("id_ed25519"), String::from("id_rsa")];
     for k in keys_name {
         let ssh_key_path = home_dir()

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -2,7 +2,7 @@
 use std::path::PathBuf;
 
 use dirs::home_dir;
-use git2::{Cred, Error, Remote, RemoteCallbacks};
+use git2::{BranchType, Cred, Error, Remote, RemoteCallbacks, Repository};
 
 fn find_ssh_key() -> Result<PathBuf, Error> {
     let keys_name = vec![String::from("id_ed25519"), String::from("id_rsa")];
@@ -62,4 +62,26 @@ pub fn get_remote_branch_hash(url: &str, branch: &str) -> Result<String, Error> 
     }
 
     Err(git2::Error::from_str(&format!("Branch {branch} not found")))
+}
+
+/// search in current repository all remotes branches and store it in Vec<String>
+pub fn branch_wildcard() -> anyhow::Result<Vec<String>> {
+    let repo = Repository::open(".")?;
+    branch_wildcard_from_repo(&repo)
+}
+
+// search in the repo provided in argument all remotes branches and store it in Vec<String>
+pub fn branch_wildcard_from_repo(repo: &Repository) -> anyhow::Result<Vec<String>> {
+    let branches = repo.branches(Some(BranchType::Remote))?;
+
+    let names: Vec<_> = branches
+        .into_iter()
+        .map(|b| {
+            let (branche, _) = b?;
+            let name = branche.name()?;
+            Ok(name.unwrap_or("").to_string())
+        })
+        .collect::<Result<Vec<_>, git2::Error>>()?;
+
+    Ok(names)
 }

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -61,8 +61,8 @@ pub fn get_remote_branch_hash(url: &str, branch: &str) -> Result<String, Error> 
     //     }
     // }
 
-    let branch_name = if branch.starts_with("origin/") {
-        &branch["origin/".len()..]
+    let branch_name = if let Some(end) = branch.strip_prefix("origin/") {
+        end
     } else {
         branch
     };

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -67,10 +67,8 @@ pub fn get_remote_branch_hash(url: &str, branch: &str) -> Result<String, Error> 
         branch
     };
 
-    println!("debug: branch in remote fn : {branch_name}");
     for r in refs {
         let name = r.name();
-        println!("debug: r.name() : {name}");
         if name.ends_with(branch_name) {
             return Ok(r.oid().to_string());
         }

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -98,7 +98,7 @@ impl Repo {
                     .ok_or_else(|| Error::from_str("Failed to parse repo name from remote URL"))?
                     .to_string();
                 Ok(Branch {
-                    branch: branch,
+                    branch,
                     last_commit: commit,
                     remote: remote.clone(),
                     name: repo_name.clone(),

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -19,8 +19,9 @@ pub struct Branch {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Branches {
     pub branches: Vec<Branch>,
-    pub last_commit: String, // the last commit who triggered a pipeline
-    pub name: String,        // the last name of the branch who triggered a pipeline
+    pub last_commit: String, // the last commit who triggered a pipeline (used for log)
+    pub last_name: String,   // the last name of the branch who triggered a pipeline
+    pub name: String, // the name of the last branch in branches: Vec<Branch> (used for ps command)
 }
 
 impl Branches {
@@ -30,6 +31,19 @@ impl Branches {
         } else {
             anyhow::bail!("failed to recover branch");
         }
+    }
+
+    pub fn last(&self) -> anyhow::Result<&Branch> {
+        if let Some(last) = self.branches.last() {
+            Ok(last)
+        } else {
+            anyhow::bail!("failed to recover branch");
+        }
+    }
+
+    pub fn default_last_commit(&self) -> anyhow::Result<String> {
+        let last = self.last()?;
+        Ok(last.last_commit.clone())
     }
 
     pub fn try_for_each<F, T>(&mut self, mut f: F) -> anyhow::Result<Vec<T>>
@@ -52,6 +66,7 @@ impl From<Vec<Branch>> for Branches {
             branches,
             last_commit: String::default(),
             name: String::default(),
+            last_name: String::default(),
         }
     }
 }
@@ -62,6 +77,7 @@ impl From<Branch> for Branches {
             branches: vec![branch],
             last_commit: String::default(),
             name: String::default(),
+            last_name: String::default(),
         }
     }
 }

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -3,35 +3,176 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Repo {
-    pub branch: String,
+    pub branches: Branches,
+    pub name: String,
     pub remote: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Branch {
+    pub branch: String,
     pub last_commit: String,
+    pub remote: String,
     pub name: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Branches {
+    pub branches: Vec<Branch>,
+}
+
+impl Branches {
+    pub fn new() -> Self {
+        Branches {
+            branches: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, branch: Branch) {
+        self.branches.push(branch);
+    }
+
+    pub fn last(&self) -> anyhow::Result<Branch> {
+        if let Some(last) = self.branches.last().cloned() {
+            Ok(last)
+        } else {
+            anyhow::bail!("failed to recover branch");
+        }
+    }
+
+    pub fn last_mut(&mut self) -> anyhow::Result<&mut Branch> {
+        if let Some(last) = self.branches.last_mut() {
+            Ok(last)
+        } else {
+            anyhow::bail!("failed to recover branch");
+        }
+    }
+
+    pub fn for_each<F>(&self, f: F)
+    where
+        F: Fn(&Branch),
+    {
+        for branch in &self.branches {
+            f(branch);
+        }
+    }
+
+    pub async fn for_each_async<F, Fut>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut Branch) -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        for branch in &mut self.branches {
+            f(branch).await;
+        }
+    }
+
+    pub async fn try_for_each_async<F, Fut>(&mut self, mut f: F) -> anyhow::Result<()>
+    where
+        F: FnMut(&mut Branch) -> Fut,
+        Fut: std::future::Future<Output = anyhow::Result<()>>,
+    {
+        for branch in &mut self.branches {
+            f(branch).await?;
+        }
+        Ok(())
+    }
+}
+
+impl From<Vec<Branch>> for Branches {
+    fn from(branches: Vec<Branch>) -> Self {
+        Branches { branches }
+    }
+}
+
+impl From<Branch> for Branches {
+    fn from(branch: Branch) -> Self {
+        Branches {
+            branches: vec![branch],
+        }
+    }
+}
+
 impl Repo {
-    pub fn build(branch_name: Option<String>) -> Result<Self, Error> {
+    pub fn build(branch_names: Vec<String>) -> anyhow::Result<Self> {
+        let repo = Repository::open(".")?;
+        let mut remote = String::new();
+        let mut repo_name = String::new();
+
+        let branches: Vec<Branch> = branch_names
+            .iter()
+            .map(|name| {
+                let (branch, commit) = {
+                    let branch_ref = repo.find_branch(name, git2::BranchType::Local)?;
+                    let target = branch_ref.get().peel_to_commit()?;
+
+                    let branch_name = branch_ref
+                        .name()?
+                        .ok_or_else(|| Error::from_str("Failed to read branch name"))?
+                        .to_string();
+
+                    (branch_name, target.id().to_string())
+                };
+                remote = repo
+                    .find_remote("origin")?
+                    .url()
+                    .ok_or_else(|| Error::from_str("Remote URL 'origin' not found"))?
+                    .to_string();
+                repo_name = remote
+                    .rsplit('/')
+                    .next()
+                    .and_then(|s| s.strip_suffix(".git").or(Some(s)))
+                    .ok_or_else(|| Error::from_str("Failed to parse repo name from remote URL"))?
+                    .to_string();
+                Ok(Branch {
+                    branch: branch,
+                    last_commit: commit,
+                    remote: remote.clone(),
+                    name: repo_name.clone(),
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(Self {
+            branches: branches.into(),
+            remote,
+            name: repo_name,
+        })
+    }
+
+    pub fn default_build() -> anyhow::Result<Self> {
         let repo = Repository::open(".")?;
 
-        let (branch, commit) = if let Some(ref name) = branch_name {
-            let branch_ref = repo.find_branch(name, git2::BranchType::Local)?;
-            let target = branch_ref.get().peel_to_commit()?;
-
-            let branch_name = branch_ref
-                .name()?
-                .ok_or_else(|| Error::from_str("Failed to read branch name"))?
-                .to_string();
-
-            (branch_name, target.id().to_string())
-        } else {
+        let branch = {
             let head = repo.head()?;
             let branch = head
                 .shorthand()
                 .ok_or_else(|| Error::from_str("Failed to read branch name"))?
                 .to_string();
             let commit_id = head.peel_to_commit()?.id().to_string();
-            (branch, commit_id)
+
+            let remote = repo
+                .find_remote("origin")?
+                .url()
+                .ok_or_else(|| Error::from_str("Remote URL 'origin' not found"))?
+                .to_string();
+
+            let repo_name = remote
+                .rsplit('/')
+                .next()
+                .and_then(|s| s.strip_suffix(".git").or(Some(s)))
+                .ok_or_else(|| Error::from_str("Failed to parse repo name from remote URL"))?
+                .to_string();
+
+            Branch {
+                branch,
+                last_commit: commit_id,
+                remote: remote.clone(),
+                name: repo_name.clone(),
+            }
         };
+
+        //trash code (only for prototyping)
 
         let remote = repo
             .find_remote("origin")?
@@ -39,7 +180,7 @@ impl Repo {
             .ok_or_else(|| Error::from_str("Remote URL 'origin' not found"))?
             .to_string();
 
-        let name = remote
+        let repo_name = remote
             .rsplit('/')
             .next()
             .and_then(|s| s.strip_suffix(".git").or(Some(s)))
@@ -47,10 +188,9 @@ impl Repo {
             .to_string();
 
         Ok(Self {
-            branch,
+            branches: branch.into(),
             remote,
-            last_commit: commit,
-            name,
+            name: repo_name,
         })
     }
 }

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -10,10 +10,11 @@ pub struct Repo {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Branch {
-    pub branch: String,
-    pub last_commit: String,
-    pub remote: String,
-    pub name: String,
+    pub branch: String,      // the name of this branch
+    pub last_commit: String, // last commit of this branch
+    pub remote: String,      // remote url of the repo
+    pub name: String,        // name of the repo
+                             // (do not use if you want to retrieve the branch name, use .branch instead)
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -10,10 +10,10 @@ use pretty_assertions::assert_eq;
 #[tokio::test]
 async fn test_build_watch_request_branch_none() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli {
-        command: cli::Commands::Watch { branch: None },
+        command: cli::Commands::Watch,
     };
 
-    let repo = Repo::build(None)?;
+    let repo = Repo::default_build()?;
     let config = load_config(Path::new("./fleet.yml"))?;
 
     let watch_req = build_watch_request(&cli).await?;
@@ -21,7 +21,6 @@ async fn test_build_watch_request_branch_none() -> Result<(), Box<dyn std::error
         watch_req,
         DaemonRequest::AddWatch {
             project_dir: std::env::current_dir()?.to_string_lossy().into_owned(),
-            branch: repo.branch.clone(),
             repo: Box::new(repo),
             config: Box::new(config),
         }
@@ -32,11 +31,9 @@ async fn test_build_watch_request_branch_none() -> Result<(), Box<dyn std::error
 
 #[tokio::test]
 async fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error::Error>> {
-    let repo = Repo::build(None)?;
+    let repo = Repo::default_build()?;
     let cli = Cli {
-        command: cli::Commands::Watch {
-            branch: Some(repo.branch.clone()),
-        },
+        command: cli::Commands::Watch,
     };
 
     let config = load_config(Path::new("./fleet.yml"))?;
@@ -46,7 +43,6 @@ async fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error
         watch_req,
         DaemonRequest::AddWatch {
             project_dir: std::env::current_dir()?.to_string_lossy().into_owned(),
-            branch: repo.branch.clone(),
             repo: Box::new(repo),
             config: Box::new(config),
         }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -4,40 +4,24 @@ use core_lib::cli::builders::build_watch_request;
 use core_lib::cli::{self, Cli};
 use core_lib::config::parser::load_config;
 use core_lib::daemon::server::DaemonRequest;
+use core_lib::git::remote::branch_wildcard;
 use core_lib::git::repo::Repo;
 use pretty_assertions::assert_eq;
 
 #[tokio::test]
-async fn test_build_watch_request_branch_none() -> Result<(), Box<dyn std::error::Error>> {
-    let cli = Cli {
-        command: cli::Commands::Watch,
-    };
-
-    let repo = Repo::default_build()?;
-    let config = load_config(Path::new("./fleet.yml"))?;
-
-    let watch_req = build_watch_request(&cli).await?;
-    assert_eq!(
-        watch_req,
-        DaemonRequest::AddWatch {
-            project_dir: std::env::current_dir()?.to_string_lossy().into_owned(),
-            repo: Box::new(repo),
-            config: Box::new(config),
-        }
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
 async fn test_build_watch_request_branch_some() -> Result<(), Box<dyn std::error::Error>> {
-    let repo = Repo::default_build()?;
     let cli = Cli {
         command: cli::Commands::Watch,
     };
 
     let config = load_config(Path::new("./fleet.yml"))?;
-
+    let (branches, b_name) = if config.branches[0] == "*" {
+        (branch_wildcard()?, "*".to_string())
+    } else {
+        (config.branches.clone(), config.branches[0].clone())
+    };
+    let mut repo = Repo::build(branches)?;
+    repo.branches.name = b_name;
     let watch_req = build_watch_request(&cli).await?;
     assert_eq!(
         watch_req,

--- a/tests/git_test.rs
+++ b/tests/git_test.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::fs::{self};
 
 use anyhow::Result;
 use core_lib::git::remote::branch_wildcard_from_repo;

--- a/tests/git_test.rs
+++ b/tests/git_test.rs
@@ -1,0 +1,73 @@
+use std::fs;
+
+use anyhow::Result;
+use core_lib::git::remote::branch_wildcard_from_repo;
+use git2::Repository;
+use tempfile::tempdir;
+
+#[test]
+fn test_branch_wildcard_with_remote_branches() -> Result<()> {
+    let dir = tempdir()?;
+    let repo = Repository::init(dir.path())?;
+
+    let remotes_dir = dir.path().join(".git/refs/remotes/origin");
+    fs::create_dir_all(&remotes_dir)?;
+
+    fs::write(
+        remotes_dir.join("main"),
+        "0123456789abcdef0123456789abcdef01234567",
+    )?;
+    fs::write(
+        remotes_dir.join("dev"),
+        "89abcdef0123456789abcdef0123456789abcdef",
+    )?;
+
+    let result = branch_wildcard_from_repo(&repo)?;
+
+    assert_eq!(
+        result,
+        vec!["origin/dev".to_string(), "origin/main".to_string()]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_no_remote_branches_returns_empty_vec() -> Result<()> {
+    let dir = tempdir()?;
+    let repo = Repository::init(dir.path())?;
+
+    let result = branch_wildcard_from_repo(&repo)?;
+    assert!(result.is_empty());
+    Ok(())
+}
+
+#[test]
+fn test_multiple_remotes() -> Result<()> {
+    let dir = tempdir()?;
+    let repo = Repository::init(dir.path())?;
+
+    let origin_dir = dir.path().join(".git/refs/remotes/origin");
+    let upstream_dir = dir.path().join(".git/refs/remotes/upstream");
+    fs::create_dir_all(&origin_dir)?;
+    fs::create_dir_all(&upstream_dir)?;
+
+    fs::write(
+        origin_dir.join("main"),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )?;
+    fs::write(
+        upstream_dir.join("feature"),
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    )?;
+
+    let mut branches = branch_wildcard_from_repo(&repo)?;
+    branches.sort();
+
+    assert_eq!(
+        branches,
+        vec!["origin/main".to_string(), "upstream/feature".to_string()]
+    );
+
+    Ok(())
+}

--- a/tests/scheduler_test.rs
+++ b/tests/scheduler_test.rs
@@ -4,13 +4,20 @@ use core_lib::{
     config::{Cmd, Job, Pipeline, ProjectConfig},
     core::watcher::{WatchContext, WatchContextBuilder},
     exec::pipeline::run_pipeline,
-    git::repo::Repo,
+    git::repo::{Branch, Branches, Repo},
 };
 
 fn build_repo() -> Repo {
     Repo {
-        branch: "main".to_string(),
-        last_commit: "abc".to_string(),
+        branches: Branches {
+            name: "main".to_string(),
+            branches: vec![Branch {
+                name: "main".to_string(),
+                remote: "git://github.com/pepedinho/fleet.git".to_string(),
+                ..Default::default()
+            }],
+            last_commit: "abc".to_string(),
+        },
         name: "name".to_string(),
         remote: "git://github.com/pepedinho/fleet.git".to_string(),
     }
@@ -22,19 +29,13 @@ async fn build_test_ctx(id: &str, jobs: HashMap<String, Job>) -> anyhow::Result<
             jobs,
             ..Default::default()
         },
-        branch: None,
+        branches: vec![],
         timeout: None,
     };
     Ok(Arc::new(
-        WatchContextBuilder::new(
-            "main".to_string(),
-            build_repo(),
-            config,
-            ".".to_string(),
-            id.to_string(),
-        )
-        .build()
-        .await?,
+        WatchContextBuilder::new(build_repo(), config, ".".to_string(), id.to_string())
+            .build()
+            .await?,
     ))
 }
 
@@ -507,12 +508,11 @@ async fn test_timeout_job() -> anyhow::Result<()> {
             jobs,
             ..Default::default()
         },
-        branch: None,
+        branches: vec![],
         timeout: Some(2),
     };
     let ctx = Arc::new(
         WatchContextBuilder::new(
-            "main".to_string(),
             build_repo(),
             config,
             ".".to_string(),

--- a/tests/scheduler_test.rs
+++ b/tests/scheduler_test.rs
@@ -17,6 +17,7 @@ fn build_repo() -> Repo {
                 ..Default::default()
             }],
             last_commit: "abc".to_string(),
+            last_name: "main".to_string(),
         },
         name: "name".to_string(),
         remote: "git://github.com/pepedinho/fleet.git".to_string(),


### PR DESCRIPTION
This pull request introduces significant changes to how branches are managed and watched within the project, moving from single-branch to multi-branch support. The updates affect the configuration format, CLI, core logic, and Git utilities, enabling the system to handle multiple branches (including wildcards) more robustly and flexibly.

**Branch and Watch Management Refactor**

* The configuration now supports a `branches` array instead of a single `branch`, allowing for multiple or wildcard branches to be specified in `fleet.yml`. [[1]](diffhunk://#diff-b0ba3e54b6f5ef1fa6aed8075e352a68fda66067fbafa8421042a2347801338aL39-R39) [[2]](diffhunk://#diff-42b333f6fabb841a7d0e7ebdbcf40f06448135e3ac5d690c96af35f20c576645R7-R8)
* The `Watch` command and related logic are refactored to remove the branch argument, instead deriving branches from configuration and supporting wildcards. [[1]](diffhunk://#diff-82453e80e064c58b8fe1569389172f4a10adc0e685de6c3a787e07bcd9d98cffL21-R21) [[2]](diffhunk://#diff-558ba3ec53bf97cb981fdee3dbec404afde7127532952a974ffa341ff4c61c1bL24-R23) [[3]](diffhunk://#diff-558ba3ec53bf97cb981fdee3dbec404afde7127532952a974ffa341ff4c61c1bL39-R38) [[4]](diffhunk://#diff-558ba3ec53bf97cb981fdee3dbec404afde7127532952a974ffa341ff4c61c1bL48-L55)
* The `WatchContext` and its builder no longer store a direct `branch` field; branch information is now encapsulated within the `Repo` structure, reflecting multi-branch support. [[1]](diffhunk://#diff-d401c00032accc7ecd310aefb98b95093cc4ac30b34cb60d2cca96c48994529bL16) [[2]](diffhunk://#diff-d401c00032accc7ecd310aefb98b95093cc4ac30b34cb60d2cca96c48994529bL27) [[3]](diffhunk://#diff-d401c00032accc7ecd310aefb98b95093cc4ac30b34cb60d2cca96c48994529bL37-L45) [[4]](diffhunk://#diff-d401c00032accc7ecd310aefb98b95093cc4ac30b34cb60d2cca96c48994529bL60)

**Core Logic and Supervisor Updates**

* The supervisor loop and update logic are updated to iterate over all watched branches, log new commits, and handle branch switching as needed. The commit update mechanism is adapted to the new branch structure. [[1]](diffhunk://#diff-c9847c547ca0495aef85e46e1ea46d90538caffb0cc2994c2173cc630a1b63e2L29-R32) [[2]](diffhunk://#diff-c9847c547ca0495aef85e46e1ea46d90538caffb0cc2994c2173cc630a1b63e2L54-R76) [[3]](diffhunk://#diff-c9847c547ca0495aef85e46e1ea46d90538caffb0cc2994c2173cc630a1b63e2L74-R93)
* The `watch_once` function is refactored to check all configured branches for updates, updating the last commit and branch name accordingly.

**Git Utilities Enhancements**

* Added `branch_wildcard` and `branch_wildcard_from_repo` functions to enumerate all remote branches, supporting wildcard branch configuration.
* Improved remote branch hash lookup to be more robust with branch naming conventions.
* Exposed `find_ssh_key` for external use and suppressed dead code warnings in the Git module. [[1]](diffhunk://#diff-7ac34c894469017b7cb26b24ca0d9fa2aff0bf7bab890d88af71c2bffbe33674R1) [[2]](diffhunk://#diff-0073c9a27345cf964e54c51744e38387e5af61885490c1f251c95e9d2203033aL5-R7)

**Daemon and API Changes**

* The `AddWatch` request and handler now operate without a direct branch argument, instead using the new multi-branch repo structure. [[1]](diffhunk://#diff-e6444b0a29e2673014c9f0e4f17eb2c5084cbcd06617684f967e21ae4f0a3405L32) [[2]](diffhunk://#diff-e6444b0a29e2673014c9f0e4f17eb2c5084cbcd06617684f967e21ae4f0a3405L127-R127) [[3]](diffhunk://#diff-e6444b0a29e2673014c9f0e4f17eb2c5084cbcd06617684f967e21ae4f0a3405L183-R191)
* Listing watches now displays the correct branch and commit information based on the new structure.

**Miscellaneous**

* Added a utility function `format_commit` to standardize commit hash formatting.
* Updated test configuration and imports to reflect new branch logic and added a wildcard branch to the default config. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL59-R59) [[2]](diffhunk://#diff-558ba3ec53bf97cb981fdee3dbec404afde7127532952a974ffa341ff4c61c1bL6-R9)

These changes collectively modernize and generalize the branch watching mechanism, setting the stage for more advanced workflows and better scalability.

---

**Configuration and CLI Refactor**
- Changed `fleet.yml` to use a `branches` array (supports multiple and wildcard branches). [[1]](diffhunk://#diff-b0ba3e54b6f5ef1fa6aed8075e352a68fda66067fbafa8421042a2347801338aL39-R39) [[2]](diffhunk://#diff-42b333f6fabb841a7d0e7ebdbcf40f06448135e3ac5d690c96af35f20c576645R7-R8)
- Refactored `Watch` CLI command and related builder logic to remove branch argument and use branches from config. [[1]](diffhunk://#diff-82453e80e064c58b8fe1569389172f4a10adc0e685de6c3a787e07bcd9d98cffL21-R21) [[2]](diffhunk://#diff-558ba3ec53bf97cb981fdee3dbec404afde7127532952a974ffa341ff4c61c1bL24-R23) [[3]](diffhunk://#diff-558ba3ec53bf97cb981fdee3dbec404afde7127532952a974ffa341ff4c61c1bL39-R38) [[4]](diffhunk://#diff-558ba3ec53bf97cb981fdee3dbec404afde7127532952a974ffa341ff4c61c1bL48-L55)

**Core and Supervisor Logic**
- Updated supervisor and `watch_once` logic to handle multiple branches, log new commits, and switch branches as needed. [[1]](diffhunk://#diff-c9847c547ca0495aef85e46e1ea46d90538caffb0cc2994c2173cc630a1b63e2L29-R32) [[2]](diffhunk://#diff-c9847c547ca0495aef85e46e1ea46d90538caffb0cc2994c2173cc630a1b63e2L54-R76) [[3]](diffhunk://#diff-d401c00032accc7ecd310aefb98b95093cc4ac30b34cb60d2cca96c48994529bL117-R131) [[4]](diffhunk://#diff-c9847c547ca0495aef85e46e1ea46d90538caffb0cc2994c2173cc630a1b63e2L74-R93)
- Removed direct `branch` field from `WatchContext` and builder; branch info now in `Repo`. [[1]](diffhunk://#diff-d401c00032accc7ecd310aefb98b95093cc4ac30b34cb60d2cca96c48994529bL16) [[2]](diffhunk://#diff-d401c00032accc7ecd310aefb98b95093cc4ac30b34cb60d2cca96c48994529bL27) [[3]](diffhunk://#diff-d401c00032accc7ecd310aefb98b95093cc4ac30b34cb60d2cca96c48994529bL37-L45) [[4]](diffhunk://#diff-d401c00032accc7ecd310aefb98b95093cc4ac30b34cb60d2cca96c48994529bL60)

**Git Utilities**
- Added `branch_wildcard` and related functions to enumerate remote branches for wildcard support.
- Improved remote branch hash lookup for better compatibility with branch naming.

**Daemon and API**
- Updated `AddWatch` request and handler to work with multi-branch repo structure. [[1]](diffhunk://#diff-e6444b0a29e2673014c9f0e4f17eb2c5084cbcd06617684f967e21ae4f0a3405L32) [[2]](diffhunk://#diff-e6444b0a29e2673014c9f0e4f17eb2c5084cbcd06617684f967e21ae4f0a3405L127-R127) [[3]](diffhunk://#diff-e6444b0a29e2673014c9f0e4f17eb2c5084cbcd06617684f967e21ae4f0a3405L183-R191)
- Improved watch listing to show branch and commit info from new structure.

**Utilities and Misc**
- Added `format_commit` for commit hash formatting.
- Updated test workflow and imports for new branch logic. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL59-R59) [[2]](diffhunk://#diff-558ba3ec53bf97cb981fdee3dbec404afde7127532952a974ffa341ff4c61c1bL6-R9)